### PR TITLE
Add bearer auth

### DIFF
--- a/fern/definition/api.yml
+++ b/fern/definition/api.yml
@@ -1,13 +1,18 @@
 name: api
 display-name: Pier API
-# TODO: add non-basic auth and the token generation endpoint in docs
 auth:
-  scheme: basic
-  docs: |
-    Use your API client ID as the username and your API client secret as the password.
+  scheme: bearer
+  docs: >
+    Use your API client ID and API client secret passed into the body of the `/token` endpoint to generate a JWT.
 environments:
   Production: https://production.pier-finance.com/api
   Sandbox: https://sandbox.pier-finance.com/api
 default-environment: Production
 error-discrimination:
   strategy: status-code
+imports:
+  commons: commons.yml
+errors:
+  - commons.ServerError
+  - commons.RateLimitError
+  - commons.UnauthorizedError

--- a/fern/definition/applications.yml
+++ b/fern/definition/applications.yml
@@ -38,7 +38,6 @@ service:
               docs: For credit applications of type `consumer_bnpl`, the third party (i.e. merchant) receiving the funds is
       response: Application
       errors:
-        - commons.ServerError
         - commons.InvalidInputError
         - commons.BorrowerNotFoundError
       examples:
@@ -58,7 +57,6 @@ service:
       request: list<Offer>
       response: Application
       errors:
-        - commons.ServerError
         - commons.InvalidInputError
         - commons.BorrowerNotFoundError
       examples:
@@ -85,7 +83,6 @@ service:
             rejection_reasons: list<RejectionReason>
       response: Application
       errors:
-        - commons.ServerError
         - commons.InvalidInputError
         - commons.ApplicationNotFoundError
       examples:
@@ -105,7 +102,6 @@ service:
       method: GET
       response: Application
       errors:
-        - commons.ServerError
         - commons.ApplicationNotFoundError
         - commons.InvalidApplicationIdError
       examples:
@@ -120,8 +116,6 @@ service:
       path: ""
       method: GET
       response: list<Application>
-      errors:
-        - commons.ServerError
       examples:
         - response:
             body:

--- a/fern/definition/auth.yml
+++ b/fern/definition/auth.yml
@@ -1,0 +1,55 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/fern-api/fern/main/fern.schema.json
+
+docs: |
+  The auth endpoint(s) support `Bearer` JWT authentication as a strong alternative to `basic` auth. 
+  To use this, you must first generate a JWT token by calling the `/token` endpoint with your API 
+  client ID and API client secret. This token will expire after 24 hours, at which point you will 
+  need to generate a new one.
+
+imports:
+  commons: commons.yml
+
+service:
+  base-path: /token
+  auth: false
+  endpoints:
+    getToken:
+      display-name: Get a JWT token
+      docs: >
+        Get a JWT token for use with the Pier API by passing in a valid `client_id`/`secret` in the body
+      path: ""
+      method: POST
+      request: AuthRequest
+      response: AuthResponse
+      errors:
+        - commons.ServerError
+        - commons.RateLimitError
+        - commons.UnauthorizedError
+      examples:
+        - request: $AuthRequest.Default
+          response:
+            body: $AuthResponse.Default
+
+types:
+    AuthRequest:
+      properties:
+        client_id:
+          type: string
+          docs: Your Pier API client ID
+        secret:
+          type: string
+          docs: Your Pier API client secret
+      examples:
+        - name: Default
+          value:
+            client_id: "1234567890"
+            secret: "1234567890"
+    AuthResponse:
+      properties:
+        token:
+          type: string
+          docs: A JWT token to use with the Pier API (24h expiration)
+      examples:
+        - name: Default
+          value:
+            token: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c"

--- a/fern/definition/auth.yml
+++ b/fern/definition/auth.yml
@@ -21,10 +21,6 @@ service:
       method: POST
       request: AuthRequest
       response: AuthResponse
-      errors:
-        - commons.ServerError
-        - commons.RateLimitError
-        - commons.UnauthorizedError
       examples:
         - request: $AuthRequest.Default
           response:

--- a/fern/definition/borrowers.yml
+++ b/fern/definition/borrowers.yml
@@ -19,7 +19,6 @@ service:
       request: BusinessBorrowerRequest
       response: BusinessBorrower
       errors:
-        - commons.ServerError
         - commons.InvalidInputError
         - commons.DuplicateEinError
       examples:
@@ -39,7 +38,6 @@ service:
       request: UpdateBusinessBorrowerRequest
       response: BusinessBorrower
       errors:
-        - commons.ServerError
         - commons.InvalidInputError
         - commons.BorrowerNotFoundError
         - commons.DuplicateEinError
@@ -60,7 +58,6 @@ service:
       request: ConsumerBorrowerRequest
       response: ConsumerBorrowerResponse
       errors:
-        - commons.ServerError
         - commons.InvalidInputError
         - commons.DuplicateSsnError
       examples:
@@ -80,7 +77,6 @@ service:
       request: UpdateConsumerBorrowerRequest
       response: ConsumerBorrowerResponse
       errors:
-        - commons.ServerError
         - commons.InvalidInputError
         - commons.BorrowerNotFoundError
       examples:

--- a/fern/definition/commons.yml
+++ b/fern/definition/commons.yml
@@ -79,7 +79,6 @@ types:
       - failed
       - cancelled
 
-  # TODO: make sure this lines up with either validator.js or Application.CreditTypes in Pier api...what is truth source?
   CreditType:
     enum:
       - consumer_installment_loan
@@ -237,4 +236,8 @@ errors:
 
   InvalidWebhookError:
     status-code: 400
+    type: ErrorBody
+
+  UnauthorizedError:
+    status-code: 401
     type: ErrorBody

--- a/fern/definition/configuration.yml
+++ b/fern/definition/configuration.yml
@@ -44,13 +44,15 @@ service:
       display-name: Verify a webhook with Pier public key
       path: "/webhook-verification"
       method: GET
-      response:
-        body:
-          properties:
-            public_key:
-              type: string
-              docs: The `public_key` to use to verify Pier webhook signatures
+      response: VerificationResponse
       examples:
         - response:
             body:
               public_key: "-----BEGIN PUBLIC KEY-----\nMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ\njkdfhdfjskfhsd==\n-----END PUBLIC KEY-----"
+
+types:
+  VerificationResponse:
+    properties:
+        public_key:
+            type: string
+            docs: The `public_key` to use to verify Pier webhook signatures

--- a/fern/definition/configuration.yml
+++ b/fern/definition/configuration.yml
@@ -23,7 +23,6 @@ service:
               docs: The `url` to send webhooks to
       response: string
       errors:
-        - commons.ServerError
         - commons.InvalidWebhookError
       examples:
         - request:
@@ -36,9 +35,22 @@ service:
       path: "/webhook"
       method: DELETE
       response: string
-      errors:
-        - commons.ServerError
       examples:
         - request:
           response:
             body: Ok.
+
+    verification:
+      display-name: Verify a webhook with Pier public key
+      path: "/webhook-verification"
+      method: GET
+      response:
+        body:
+          properties:
+            public_key:
+              type: string
+              docs: The `public_key` to use to verify Pier webhook signatures
+      examples:
+        - response:
+            body:
+              public_key: "-----BEGIN PUBLIC KEY-----\nMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ\njkdfhdfjskfhsd==\n-----END PUBLIC KEY-----"

--- a/fern/definition/coverage.yml
+++ b/fern/definition/coverage.yml
@@ -10,7 +10,7 @@ imports:
   applications: applications.yml
 
 service:
-  base-path: /
+  base-path: ""
   auth: true
   endpoints:
     retrieveCommercialCoverage:
@@ -19,8 +19,6 @@ service:
       path: /coverage/commercial
       method: GET
       response: map<string, CommercialCoverage>
-      errors:
-        - commons.ServerError
       examples:
         - response:
             body:
@@ -42,8 +40,6 @@ service:
       path: /coverage/consumer
       method: GET
       response: map<string, ConsumerCoverage>
-      errors:
-        - commons.ServerError
       examples:
         - response:
             body:
@@ -62,7 +58,6 @@ service:
       path: /rejection_reasons
       response: RetrieveRejectionReasonsResponse
       errors:
-        - commons.ServerError
         - commons.InvalidInputError
       examples:
         - response:

--- a/fern/definition/facilities.yml
+++ b/fern/definition/facilities.yml
@@ -31,7 +31,6 @@ service:
               docs: The `loan_agreement_id` of the loan agreement to create a facility for
       response: Facility
       errors:
-        - commons.ServerError
         - commons.FacilityCannotBeCreatedError
         - commons.FacilityAlreadyExistsError
         - commons.DocumentNotFoundError
@@ -52,7 +51,6 @@ service:
       request: DisbursementRequest
       response: Disbursement
       errors:
-        - commons.ServerError
         - commons.InvalidInputError
         - commons.FacilityNotFoundError
         - commons.LedgeringNotSupportedError
@@ -79,7 +77,6 @@ service:
       method: POST
       response: Facility
       errors:
-        - commons.ServerError
         - commons.FacilityNotFoundError
         - commons.FacilityCannotBeClosedError
       examples:
@@ -111,7 +108,6 @@ service:
               docs: The additional amount to pay on top of the minimum payment, in cents (e.g. 1000 = $10.00)
       response: Facility
       errors:
-        - commons.ServerError
         - commons.InvalidInputError
         - commons.FacilityNotFoundError
       examples:
@@ -133,7 +129,6 @@ service:
       method: POST
       response: Facility
       errors:
-        - commons.ServerError
         - commons.AutopayAlreadyDisabledError
         - commons.FacilityNotFoundError
       examples:
@@ -152,7 +147,6 @@ service:
       request: commons.BankAccount
       response: Facility
       errors:
-        - commons.ServerError
         - commons.InvalidInputError
         - commons.FacilityNotFoundError
       examples:
@@ -173,7 +167,6 @@ service:
       method: GET
       response: Facility
       errors:
-        - commons.ServerError
         - commons.InvalidFacilityIdError
         - commons.FacilityNotFoundError
       examples:
@@ -188,8 +181,6 @@ service:
       path: /disbursements
       method: GET
       response: list<Disbursement>
-      errors:
-        - commons.ServerError
       examples:
         - response:
             body:
@@ -206,7 +197,6 @@ service:
       method: GET
       response: list<Statement>
       errors:
-        - commons.ServerError
         - commons.InvalidFacilityIdError
         - commons.FacilityNotFoundError
       examples:
@@ -230,7 +220,6 @@ service:
       method: GET
       response: Disbursement
       errors:
-        - commons.ServerError
         - commons.InvalidDisbursementIdError
         - commons.DisbursementNotFoundError
       examples:
@@ -250,8 +239,6 @@ service:
           docs: The facility_id of the facility you want to list disbursements for
       method: GET
       response: list<Disbursement>
-      errors:
-        - commons.ServerError
       examples:
         - path-parameters:
             facility_id: $FacilityId.Example0
@@ -265,8 +252,6 @@ service:
       path: ""
       method: GET
       response: list<Facility>
-      errors:
-        - commons.ServerError
       examples:
         - response:
             body:
@@ -283,7 +268,6 @@ service:
       method: GET
       response: PayoffAmounts
       errors:
-        - commons.ServerError
         - commons.FacilityNotFoundError
       examples:
         - path-parameters:
@@ -416,9 +400,6 @@ types:
       statements:
         type: list<Statement>
         docs: An array of statements for the loan (empty if no statements exist)
-      monthly_payment:
-        type: optional<integer>
-        docs: The monthly payment amount, in cents
       balance:
         type: optional<integer>
         docs: The remaining balance of the loan, in cents
@@ -492,7 +473,6 @@ types:
           repayment_bank_details: $commons.BankAccount.Default
           transactions: []
           statements: []
-          monthly_payment: 124425
           next_payment_amount: 124425
           next_payment_due_date: "2023-06-12"
           current_payment_due_date: "2023-06-12"
@@ -523,7 +503,6 @@ types:
           repayment_bank_details: null
           transactions: []
           statements: []
-          monthly_payment: 124425
           next_payment_amount: 124425
           next_payment_due_date: "2023-06-12"
           current_payment_due_date: "2023-06-12"
@@ -563,7 +542,6 @@ types:
           repayment_bank_details: $commons.BankAccount.Default
           transactions: []
           statements: []
-          monthly_payment: 124425
           next_payment_amount: 124425
           next_payment_due_date: "2023-06-12"
           current_payment_due_date: "2023-06-12"

--- a/fern/definition/loan-agreements.yml
+++ b/fern/definition/loan-agreements.yml
@@ -33,7 +33,7 @@ service:
         - commons.DocumentCannotBeCreatedError
       examples:
         - request:
-            application_id: applications.ApplicationId.Example0
+            application_id: $applications.ApplicationId.Example0
           response:
             body: $LoanAgreement.Pending
 

--- a/fern/definition/loan-agreements.yml
+++ b/fern/definition/loan-agreements.yml
@@ -116,7 +116,7 @@ types:
           status: pending_signature
           id: doc_43da3b3f95c745e1985a71e9a00d6c27
           application_id: app_a9d2f388030d4f4296f80fc327e08d0d
-          document_url: https://production-formapi-docs.s3.amazonaws.com/store/acc_QqdcDH47A63qKZbK3S/templates/tpl_4zqGxezHzrfqDaxGr2/submissions/sub_J9PbHbXYbL4jzRxc3R.pdf?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAJESVN6QC4ACN3XSQ%2F20221231%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20221231T204739Z&X-Amz-Expires=900&X-Amz-SignedHeaders=host&X-Amz-Signature=cf0c6429ef72ca06d861cb912f5d1cf376a5c26c7f904aaa9bf08f10103785bd
+          document_url: https://example.com/document-endpoint-unique-hash
           created_on: "2022-12-31T20:47:38.152Z"
           signature_timestamp: null
       - name: Signed
@@ -124,7 +124,7 @@ types:
           status: signed
           id: doc_43da3b3f95c745e1985a71e9a00d6c27
           application_id: app_a9d2f388030d4f4296f80fc327e08d0d
-          document_url: https://production-formapi-docs.s3.amazonaws.com/store/acc_QqdcDH47A63qKZbK3S/templates/tpl_4zqGxezHzrfqDaxGr2/submissions/sub_J9PbHbXYbL4jzRxc3R.pdf?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAJESVN6QC4ACN3XSQ%2F20221231%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20221231T204739Z&X-Amz-Expires=900&X-Amz-SignedHeaders=host&X-Amz-Signature=cf0c6429ef72ca06d861cb912f5d1cf376a5c26c7f904aaa9bf08f10103785bd
+          document_url: https://example.com/document-endpoint-unique-hash
           created_on: "2022-12-31T20:47:38.152Z"
           signature_timestamp: "2022-12-31T21:10:47.610Z"
 
@@ -149,7 +149,7 @@ types:
           id: doc_96d13bec673c4eba8d44c9cda3bbb811
           application_id: app_a9d2f388030d4f4296f80fc327e08d0d
           signature_timestamp: null
-          document_url: https://production-formapi-docs.s3.amazonaws.com/store/acc_QqdcDH47A63qKZbK3S/templates/tpl_4zqGxezHzrfqDaxGr2/submissions/sub_jQRTtHgekEbdJTxtsR.pdf?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAJESVN6QC4ACN3XSQ%2F20221231%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20221231T210718Z&X-Amz-Expires=900&X-Amz-SignedHeaders=host&X-Amz-Signature=9ead57dba9e8e2179a3e9950f1c7c19fe8b10dfbc55f5ce09228bd216e4cdd73
+          document_url: https://example.com/document-endpoint-unique-hash
           created_on: "2022-12-31T21:07:16.642Z"
       - name: Signed
         value:
@@ -157,5 +157,5 @@ types:
           id: doc_96d13bec673c4eba8d44c9cda3bbb811
           application_id: app_a9d2f388030d4f4296f80fc327e08d0d
           signature_timestamp: "2022-12-31T21:10:47.610Z"
-          document_url: https://production-formapi-docs.s3.amazonaws.com/store/acc_QqdcDH47A63qKZbK3S/templates/tpl_4zqGxezHzrfqDaxGr2/submissions/sub_jQRTtHgekEbdJTxtsR.pdf?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAJESVN6QC4ACN3XSQ%2F20221231%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20221231T210718Z&X-Amz-Expires=900&X-Amz-SignedHeaders=host&X-Amz-Signature=9ead57dba9e8e2179a3e9950f1c7c19fe8b10dfbc55f5ce09228bd216e4cdd73
+          document_url: https://example.com/document-endpoint-unique-hash
           created_on: "2022-12-31T21:07:16.642Z"

--- a/fern/definition/payments.yml
+++ b/fern/definition/payments.yml
@@ -20,7 +20,6 @@ service:
       request: PaymentRequest
       response: Payment
       errors:
-        - commons.ServerError
         - commons.InvalidInputError
         - commons.FacilityNotFoundError
         - commons.PaymentBalanceLessThanAmountError
@@ -41,7 +40,6 @@ service:
       method: GET
       response: Payment
       errors:
-        - commons.ServerError
         - commons.PaymentNotFoundError
         - commons.InvalidPaymentIdError
       examples:
@@ -56,8 +54,6 @@ service:
       path: ""
       method: GET
       response: list<Payment>
-      errors:
-        - commons.ServerError
       examples:
         - response:
             body:

--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -22,6 +22,7 @@ navigation:
       - page: Buy Now Pay Later program
         path: ./docs/pages/buy-now-pay-later.mdx
   - api: API Reference
+    display-errors: true
 colors:
   accentPrimary:
     dark: '#aa8ff6'

--- a/fern/docs/pages/buy-now-pay-later.mdx
+++ b/fern/docs/pages/buy-now-pay-later.mdx
@@ -32,7 +32,6 @@ Buy Now Pay Later Loans leverage the standard Loan Offer object, including the f
 
 The following example models a loan offer with an amount of $1,000.00, 13% interest rate, monthly payment period and 12 payments:
 
-```js
 {
   "amount": 100000,
   "interest_rate": 1300,

--- a/fern/docs/pages/quickstart.mdx
+++ b/fern/docs/pages/quickstart.mdx
@@ -13,15 +13,34 @@ The sandbox is designed to mimic the production environment, with a few exceptio
 
 ## Postman Collection
 
-# TODO: update this section with new postman collection; pre-request script reference; and new variable setup; talk about hitting token endpoint
-
-You can fork our [Postman Collection](https://www.postman.com/martian-comet-959825/workspace/pier-public/collection/14754440-cf96aaa5-d588-4a09-b4a0-66c32b77e33c?action=share&creator=14754440) to immediately start interacting with the API. You'll need to set a few variables to get started:
+You can fork our [Postman Collection](https://www.postman.com/martian-comet-959825/workspace/pier-public/collection/30375005-403d3b8d-925c-4f59-86c0-6e701a2ec6d4?action=share&creator=30375005) to immediately start interacting with the API. You'll need to set a few variables to get started:
 
 | Variable   | Description       |
 |------------|-------------------|
-| `client_id` | Your API client ID |
-| `api_secret` | Your API secret     |
-| `base_url`  | This should generally be set to `https://sandbox.pier-finance.com/api` |
+| `clientId` | Your API client ID (add this to the collection level `Variables`) |
+| `secret` | Your API secret (add this to the collection level `Variables`)     |
+| `token` | The JWT token you get back from the `/token` endpoint (this goes in the `Authorization` header of each request; the `Pre-request Script` will set/update it for you) |
+| `baseUrl`  | This should generally be set to `https://sandbox.pier-finance.com/api` |
+
+When you open the collection click on the top level titled `Pier Api` and choose `Variables`. Create the variables `clientId`/`secret` and set the `Current value` field (prevents credentials leaking). You are good to go! The `Pre-request Script` will now automatically fill out the `token` variable for each request:
+
+```javascript
+pm.sendRequest({
+  url:  pm.collectionVariables.get('baseUrl') + '/token',
+  method: 'POST',
+  header: {
+    'Content-Type': 'application/json'
+  },
+  body: {
+    mode: 'raw',
+    raw: JSON.stringify({client_id: pm.collectionVariables.get('clientId'), secret: pm.collectionVariables.get('secret')})
+  }
+}, function (err, res) {
+    pm.collectionVariables.set('token', res.json().token);
+});
+```
+
+This is a convenience that sets the token automatically each request and is simply calling the [`/token`](/api-reference/auth/get-a-jwt-token) endpoint like you would in your application.
 
 ## Authentication
 

--- a/fern/docs/pages/quickstart.mdx
+++ b/fern/docs/pages/quickstart.mdx
@@ -23,7 +23,9 @@ You can fork our [Postman Collection](https://www.postman.com/martian-comet-9598
 
 ### Authentication
 
-Pier uses basic auth to authenticate API requests. All calls should be made with the `username` field set to your `client_id` and the `password` field set to your `api_secret`. Make sure to `base64` encode the `username:password` portion.
+Pier uses bearer auth to authenticate API requests. Call the [`/token`](/api-reference/auth/get-a-jwt-token) endpoint using `client_id` and `secret` in the post body to get a JWT token. The token should be included in the `Authorization` header of all subsequent requests in the format of `Bearer ${token}`.
+
+```shell
 
 ## Rate limits and retrying API requests
 
@@ -46,7 +48,7 @@ The following diagram outlines how the Pier origination flow works with the Borr
 ```shell
 curl -X POST https://sandbox.pier-finance.com/api/borrowers/consumer \
 -H 'Content-Type: application/json' \
--H 'Authorization: Basic ${PIER_CREDENTIALS_BASE64_ENCODED}' \
+-H 'Authorization: Bearer ${PIER_ISSUED_JWT}' \
 -d '{
     "address": {
         "line_1": "15 Main Street",
@@ -69,7 +71,7 @@ curl -X POST https://sandbox.pier-finance.com/api/borrowers/consumer \
 ```shell
 curl -X POST https://sandbox.pier-finance.com/api/applications \
 -H 'Content-Type: application/json' \
--H 'Authorization: Basic ${PIER_CREDENTIALS_BASE64_ENCODED}' \
+-H 'Authorization: Bearer ${PIER_ISSUED_JWT}' \
 -d '{
     "borrower_id": "bor_7b1b1f0d97554532a2681e4159ec2a8a",
     "credit_type": "consumer_installment_loan"
@@ -81,7 +83,7 @@ curl -X POST https://sandbox.pier-finance.com/api/applications \
 ```shell
 curl -X POST https://sandbox.pier-finance.com/api/applications/app_ae982db618544da9ac6fad552cede6f0/approve \
 -H 'Content-Type: application/json' \
--H 'Authorization: Basic ${PIER_CREDENTIALS_BASE64_ENCODED}' \
+-H 'Authorization: Bearer ${PIER_ISSUED_JWT}' \
 -d '{
     "offers":[{
         "amount": 2000000,
@@ -103,7 +105,7 @@ curl -X POST https://sandbox.pier-finance.com/api/applications/app_ae982db618544
 ```shell
 curl -X POST https://sandbox.pier-finance.com/api/loan_agreements \
 -H 'Content-Type: application/json' \
--H 'Authorization: Basic ${PIER_CREDENTIALS_BASE64_ENCODED}' \
+-H 'Authorization: Bearer ${PIER_ISSUED_JWT}' \
 -d '{
     "application_id": "app_ae982db618544da9ac6fad552cede6f0",
     "accepted_offer_id": "off_b71c4524ac57467e982ce5414800c27f"
@@ -115,7 +117,7 @@ curl -X POST https://sandbox.pier-finance.com/api/loan_agreements \
 ```shell
 curl -X POST https://sandbox.pier-finance.com/api/loan_agreements/doc_6f9c7af667024d5f837ae5a0fb942a8a/sign \
 -H 'Content-Type: application/json' \
--H 'Authorization: Basic ${PIER_CREDENTIALS_BASE64_ENCODED}' \
+-H 'Authorization: Bearer ${PIER_ISSUED_JWT}' \
 -d '{}'
 ```
 
@@ -124,7 +126,7 @@ curl -X POST https://sandbox.pier-finance.com/api/loan_agreements/doc_6f9c7af667
 ```shell
 curl -X POST https://sandbox.pier-finance.com/api/facilities \
 -H 'Content-Type: application/json' \
--H 'Authorization: Basic ${PIER_CREDENTIALS_BASE64_ENCODED}' \
+-H 'Authorization: Bearer ${PIER_ISSUED_JWT}' \
 -d '{
     "loan_agreement_id": "doc_6f9c7af667024d5f837ae5a0fb942a8a"
 }'

--- a/fern/docs/pages/quickstart.mdx
+++ b/fern/docs/pages/quickstart.mdx
@@ -25,8 +25,6 @@ You can fork our [Postman Collection](https://www.postman.com/martian-comet-9598
 
 Pier uses bearer auth to authenticate API requests. Call the [`/token`](/api-reference/auth/get-a-jwt-token) endpoint using `client_id` and `secret` in the post body to get a JWT token. The token should be included in the `Authorization` header of all subsequent requests in the format of `Bearer ${token}`.
 
-```shell
-
 ## Rate limits and retrying API requests
 
 Only 5xx (Server Errors) and 429 (Rate Limits) errors should be retried.

--- a/fern/docs/pages/quickstart.mdx
+++ b/fern/docs/pages/quickstart.mdx
@@ -11,7 +11,9 @@ The Pier API is accessible in two environments:
 
 The sandbox is designed to mimic the production environment, with a few exceptions. Loan agreements created in the sandbox will have large 'draft' watermarks and funds flows will only occur in production. Sandbox API keys are prefixed with `test_` while production API keys are prefixed with `prod_`. Otherwise, sandbox and production behavior is identical.
 
-### Postman Collection
+## Postman Collection
+
+# TODO: update this section with new postman collection; pre-request script reference; and new variable setup; talk about hitting token endpoint
 
 You can fork our [Postman Collection](https://www.postman.com/martian-comet-959825/workspace/pier-public/collection/14754440-cf96aaa5-d588-4a09-b4a0-66c32b77e33c?action=share&creator=14754440) to immediately start interacting with the API. You'll need to set a few variables to get started:
 
@@ -21,7 +23,7 @@ You can fork our [Postman Collection](https://www.postman.com/martian-comet-9598
 | `api_secret` | Your API secret     |
 | `base_url`  | This should generally be set to `https://sandbox.pier-finance.com/api` |
 
-### Authentication
+## Authentication
 
 Pier uses bearer auth to authenticate API requests. Call the [`/token`](/api-reference/auth/get-a-jwt-token) endpoint using `client_id` and `secret` in the post body to get a JWT token. The token should be included in the `Authorization` header of all subsequent requests in the format of `Bearer ${token}`.
 

--- a/fern/docs/pages/webhooks.mdx
+++ b/fern/docs/pages/webhooks.mdx
@@ -14,7 +14,7 @@ Webhooks include a JWT in the `pier-webhook-verification` header. The JWT payloa
 
 To ensure the payload is sourced from Pier:
 
-1. The JWT should be verified using a library for your stack and the Pier public key (see [`/configuration/webhook-verification`](/api-reference/configuration/verify-a-webhook-with-pier-public-key)).
+1. The JWT should be verified using a library for your stack and the Pier public key (see [`/configuration/webhook-verification`](/api-reference/configuration/verify-a-webhook-with-pier-public-key)). You should replace \n with newlines in the public key before using it (e.g. `.replace(/\\n/g, "\n");`).
 1. Extract the payload from the JWT.
 1. Extract the SHA256 signature from the JWT payload `request_body_sha256` field.
 1. Compute the SHA256 signature of the webhook payload.

--- a/fern/docs/pages/webhooks.mdx
+++ b/fern/docs/pages/webhooks.mdx
@@ -14,7 +14,7 @@ Webhooks include a JWT in the `pier-webhook-verification` header. The JWT payloa
 
 To ensure the payload is sourced from Pier:
 
-1. The JWT should be verified using a library for your stack and the Pier public key.
+1. The JWT should be verified using a library for your stack and the Pier public key (see [`/configuration/webhook-verification`](/api-reference/configuration/verify-a-webhook-with-pier-public-key)).
 1. Extract the payload from the JWT.
 1. Extract the SHA256 signature from the JWT payload `request_body_sha256` field.
 1. Compute the SHA256 signature of the webhook payload.
@@ -38,21 +38,21 @@ More details about `identifiers` and `details` for each event can be found in th
 
 ```json
 {
-	"type": "payment",
+  "type": "payment",
   "code": "transaction_failed",
   "env": "sandbox",
   "url": "https://example.com/webhook",
   "timestamp": "2023-12-05T01:04:44+0000",
   "identifiers": {
 	"statement_id": "sta_7b1b1f0d97554532a2681e4159ec2a8a",
-    "facility_id": "fac_b71c4524ac57467e982ce5414800c27f",
-  }
+    "facility_id": "fac_b71c4524ac57467e982ce5414800c27f"
+  },
   "details": {
 		"failure": {
 	    "reason_code": "R01",
       "description": "Insufficient Funds"
   }
-}   
+}
 }
 ```
 

--- a/fern/docs/pages/webhooks.mdx
+++ b/fern/docs/pages/webhooks.mdx
@@ -14,7 +14,7 @@ Webhooks include a JWT in the `pier-webhook-verification` header. The JWT payloa
 
 To ensure the payload is sourced from Pier:
 
-1. The JWT should be verified using a library for your stack and the Pier public key (see [`/configuration/webhook-verification`](/api-reference/configuration/verify-a-webhook-with-pier-public-key)). You should replace \n with newlines in the public key before using it (e.g. `.replace(/\\n/g, "\n");`).
+1. The JWT should be verified using a library for your stack and the Pier public key (see [`/configuration/webhook-verification`](/api-reference/configuration/verify-a-webhook-with-pier-public-key)). You should replace `\n` with newlines in the public key before using it (e.g. `.replace(/\\n/g, "\n")`).
 1. Extract the payload from the JWT.
 1. Extract the SHA256 signature from the JWT payload `request_body_sha256` field.
 1. Compute the SHA256 signature of the webhook payload.

--- a/fern/docs/pages/webhooks.mdx
+++ b/fern/docs/pages/webhooks.mdx
@@ -48,11 +48,11 @@ More details about `identifiers` and `details` for each event can be found in th
     "facility_id": "fac_b71c4524ac57467e982ce5414800c27f"
   },
   "details": {
-		"failure": {
-	    "reason_code": "R01",
-      "description": "Insufficient Funds"
+        "failure": {
+        "reason_code": "R01",
+        "description": "Insufficient Funds"
+    }
   }
-}
 }
 ```
 


### PR DESCRIPTION
Bearer auth setup and some clarification on webhook docs

# Todo:
- [x] Update main pier postman collection to do bearer w/ jwt in pre-request script so that anyone reading docs sees our api uses it and does not use basic.
- [x] Upload new public pier postman and add pre-request script to it + docs
- [x] Link to new collection in docs

```
pm.sendRequest({
  url:  pm.collectionVariables.get('baseUrl') + '/token', 
  method: 'POST',
  header: {
    'Content-Type': 'application/json'
  },
  body: {
    mode: 'raw',
    raw: JSON.stringify({client_id: '<CLIENT_ID>', secret: '<SECRET>'})
  }
}, function (err, res) {
    console.log(res);
    pm.collectionVariables.set("token", res.json().token);
});
```