### PR TITLE
multiple webhooks

### DIFF
--- a/fern/definition/configuration.yml
+++ b/fern/definition/configuration.yml
@@ -10,37 +10,48 @@ service:
   base-path: /configuration
   auth: true
   endpoints:
-    create_webhook:
-      display-name: Set webhook URL
-      docs: Set a url to receive webhook events from Pier.
+    set_webhook_urls:
+      display-name: Set webhook URLs
+      docs: Set the array of urls to receive webhook events from Pier.
       path: "/webhook"
       method: POST
       request:
-        name: CreateWebhookRequest
+        name: SetWebhook
         body:
           properties:
-            url:
-              type: string
-              docs: The `url` to send webhooks to
-      response: string
+            urls:
+              type: list<string>
+              docs: The array of `urls` to send webhooks to
+      response: WebhookUrls
       errors:
         - commons.InvalidWebhookError
       examples:
         - request:
-            url: "https://example.com/webhook"
+            urls:
+              - "https://example.com/webhook1"
+              - "https://example.com/webhook2"
           response:
-            body: Ok.
+            body: $WebhookUrls.Default
 
-    delete_webhook:
-      display-name: Remove a webhook
-      docs: Delete the url that was set to receive webhook events from Pier.
+    delete_webhook_urls:
+      display-name: Reset webhook URLs
+      docs: Reset the array of `urls` that receives Pier webhooks.
       path: "/webhook"
       method: DELETE
-      response: string
+      response: DeleteWebhookResponse
       examples:
-        - request:
-          response:
-            body: Ok.
+        - response:
+            body: $DeleteWebhookResponse.Default
+
+    get_webhook_urls:
+      display-name: Get webhook URLs
+      docs: Get the array of `urls` that receives Pier webhooks.
+      path: "/webhook"
+      method: GET
+      response: WebhookUrls
+      examples:
+        - response:
+            body: $WebhookUrls.Default
 
     webhook_verification:
       display-name: Verify a webhook with Pier public key
@@ -84,6 +95,26 @@ service:
             body: Ok.
 
 types:
+  WebhookUrls:
+    properties:
+      urls:
+        type: list<string>
+        docs: The array of `urls` to send webhooks to
+    examples:
+      - name: Default
+        value:
+          urls:
+            - "https://example.com/webhook1"
+            - "https://example.com/webhook2"
+
+  DeleteWebhookResponse:
+    properties:
+      urls: list<string>
+    examples:
+      - name: Default
+        value:
+          urls: []
+
   VerificationResponse:
     properties:
         public_key:


### PR DESCRIPTION
# Checklist

- [ ] [Postman Collection](https://martian-comet-959825.postman.co/workspace/Pier~edf14f5c-4b28-474b-9557-734f6824cf13/overview) has been updated (when making api changes)
    -   [ ] run `fern generate`
    -   [ ] upload a new `pier-fern-def/postman/collection.json` to our public collection
    -   [ ] update the collection's `variables` tab to match the old public pier collection
    -   [ ] copy the `pre-request script` from the old public pier collection to new one
    -   [ ] copy the :ferris_wheel: in the name from the old public collection to the new one
    -   [ ] update pier-fern-def `quickstart` w/ the new public collection's shared url
    -   [ ] delete the old public pier postman
-   [ ] Make any changes to our `internal postman collection (not just your fork)` to keep it up to date w/ these changes
