### PR TITLE
Remove auth id as requirement

### DIFF
--- a/fern/definition/payments.yml
+++ b/fern/definition/payments.yml
@@ -136,8 +136,8 @@ types:
         type: commons.TransferType
         docs: The type of ACH transfer
       ach_authorization_id:
-        type: string
-        docs: The Document ID of an unused ACH authorization document
+        type: optional<string>
+        docs: The Document ID of an unused ACH authorization document (only required when `transfer_type` is not `none`)
     examples:
       - name: Default
         value:

--- a/fern/docs/pages/quickstart.mdx
+++ b/fern/docs/pages/quickstart.mdx
@@ -18,7 +18,7 @@ The sandbox is designed to mimic the production environment, with a few exceptio
 
 ## Postman Collection
 
-You can fork our [Postman Collection](https://www.postman.com/martian-comet-959825/workspace/pier-public/collection/30375005-c980a7ef-40ce-4d54-bc29-74ecdd444225?action=share&creator=30375005) to immediately start interacting with the API. You'll need to set a few variables to get started:
+You can fork our [Postman Collection](https://www.postman.com/martian-comet-959825/workspace/pier-public/collection/30375005-410acaad-36a0-4087-87e5-0910805b0c95?action=share&creator=30375005) to immediately start interacting with the API. You'll need to set a few variables to get started:
 
 | Variable   | Description       |
 |------------|-------------------|

--- a/fern/fern.config.json
+++ b/fern/fern.config.json
@@ -1,4 +1,4 @@
 {
   "organization": "pier",
-  "version": "0.30.0"
+  "version": "0.30.8"
 }


### PR DESCRIPTION
# Checklist

- [x] [Postman Collection](https://martian-comet-959825.postman.co/workspace/Pier~edf14f5c-4b28-474b-9557-734f6824cf13/overview) has been updated (when making api changes)
    -   [ ] run `fern generate`
    -   [ ] upload a new `pier-fern-def/postman/collection.json` to our public collection
    -   [ ] update the collection's `variables` tab to match the old public pier collection
    -   [ ] copy the `pre-request script` from the old public pier collection to new one
    -   [ ] copy the :ferris_wheel: in the name from the old public collection to the new one
    -   [ ] update pier-fern-def `quickstart` w/ the new public collection's shared url
    -   [ ] delete the old public pier postman
-   [x] Make any changes to our `internal postman collection (not just your fork)` to keep it up to date w/ these changes
