### PR TITLE
Updated postman so updating docs url for shared collection

### DIFF
--- a/fern/docs/pages/quickstart.mdx
+++ b/fern/docs/pages/quickstart.mdx
@@ -18,7 +18,7 @@ The sandbox is designed to mimic the production environment, with a few exceptio
 
 ## Postman Collection
 
-You can fork our [Postman Collection](https://www.postman.com/martian-comet-959825/workspace/pier-public/collection/30375005-4bd668b1-279d-4451-a2b5-577b92e00229?action=share&creator=30375005) to immediately start interacting with the API. You'll need to set a few variables to get started:
+You can fork our [Postman Collection](https://www.postman.com/martian-comet-959825/workspace/pier-public/collection/30375005-ee7e0704-7e39-4108-9923-3ab832a4a8a4?action=share&creator=30375005) to immediately start interacting with the API. You'll need to set a few variables to get started:
 
 | Variable   | Description       |
 |------------|-------------------|


### PR DESCRIPTION
# Checklist

- [ ] [Postman Collection](https://martian-comet-959825.postman.co/workspace/Pier~edf14f5c-4b28-474b-9557-734f6824cf13/overview) has been updated (when making api changes)
    -   [ ] run `fern generate`
    -   [ ] upload a new `pier-fern-def/postman/collection.json` to our public collection
    -   [ ] update the collection's `variables` tab to match the old public pier collection
    -   [ ] copy the `pre-request script` from the old public pier collection to new one
    -   [ ] copy the :ferris_wheel: in the name from the old public collection to the new one
    -   [ ] update pier-fern-def `quickstart` w/ the new public collection's shared url
    -   [ ] delete the old public pier postman
-   [ ] Make any changes to our `internal postman collection (not just your fork)` to keep it up to date w/ these changes
