### PR TITLE
PIE-724 cancelation docs follow-up

### DIFF
--- a/fern/docs/pages/errors.mdx
+++ b/fern/docs/pages/errors.mdx
@@ -94,3 +94,5 @@ Pier uses HTTP codes to indicate the status of an API request. Generally, `2xx` 
 | LEDGERING_DISABLED | LEDGERING_ERROR | 400 | Your account is not enabled for ledgering |
 | MISSING_DISBURSEMENT_BANK_DETAILS | DISBURSEMENT_ERROR | 400 | Invalid or missing disbursement bank account & routing info |
 | MISSING_LENDING_DETAILS | LOAN_AGREEMENT_ERROR | 400 | Invalid lending details for generating loan agreement |
+| CANNOT_CANCEL_TRANSACTION_INCORRECT_STATUS | PAYMENT_ERROR | 409 | Can only cancel Payment or Disbursement if the transaction's status is pending and ach has not been submitted |
+| CANNOT_REFUND_TRANSACTION_INCORRECT_STATUS | PAYMENT_ERROR | 409 | Can only refund Payment or Disbursement if the transaction's status is settled |


### PR DESCRIPTION
# Checklist

- [ ] [Postman Collection](https://martian-comet-959825.postman.co/workspace/Pier~edf14f5c-4b28-474b-9557-734f6824cf13/overview) has been updated (when making api changes)
    -   [ ] run `fern generate`
    -   [ ] upload a new `pier-fern-def/postman/collection.json` to our public collection
    -   [ ] update the collection's `variables` tab to match the old public pier collection
    -   [ ] copy the `pre-request script` from the old public pier collection to new one
    -   [ ] copy the :ferris_wheel: in the name from the old public collection to the new one
    -   [ ] update pier-fern-def `quickstart` w/ the new public collection's shared url
    -   [ ] delete the old public pier postman
-   [ ] Make any changes to our `internal postman collection (not just your fork)` to keep it up to date w/ these changes
